### PR TITLE
Assign the project name to the chaincode if not provided

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ export class CLI {
 
     constructor(public name?: string, public chaincode?: string) {
         this.analytics = new Analytics();
+        this.chaincode = this.chaincode || this.name;
     }
 
     public async init() {


### PR DESCRIPTION
Hi, this is a simple PR:

`chaincode` variable is not mandatory, so technically you can avoid it when creating a new project:

```bash
conv new project && cd $_ && npm i && npm run env:restart
```

The problem with this is, when running the project generated, this will throw an error due to it's not able to find the chaincode config file (because the project structure wasn't created).

```
lerna success run No packages found with the lifecycle script 'build'
(node:11112) UnhandledPromiseRejectionWarning: Error: {INVALID} Failed to read chaincode config file
```

So I think a good approach might be, on constructor, if chaincode name is not provided, we can take the value of the project name and assign it directly, unless of course, if chaincode is provided, it will take the given value.

Please let me know your thoughts about this.
Great project, I am excited about it, wish the best!